### PR TITLE
The automation module only recognizes uppercase in the hex encoding

### DIFF
--- a/ConcordAlarm.indigoPlugin/Contents/Server Plugin/concord/concord.py
+++ b/ConcordAlarm.indigoPlugin/Contents/Server Plugin/concord/concord.py
@@ -218,7 +218,7 @@ def update_message_checksum(bin_msg):
 def encode_message_to_ascii(bin_msg):
     s = ''
     for b in bin_msg:
-        s += '%02x' % b
+        s += '%02X' % b
     return s
 
 def decode_message_from_ascii(ascii_msg):


### PR DESCRIPTION

Page 5 of the Protocol document:

"**Data**
An 8-bit binary value is sent as two upper-case ASCII digits (‘0’...’9’, ‘A’...’F’)."

This is a suprisingly latent bug, since the most commonly used data sent to the module happens to use numbers and not hex letters.  But even then it can affect checksums sporadically.
